### PR TITLE
✨ feat: 환경 걸음 포인트 적림 및 유저 절감량 업데이트

### DIFF
--- a/src/main/java/com/penglobe/server/domain/ledger/LedgerReason.java
+++ b/src/main/java/com/penglobe/server/domain/ledger/LedgerReason.java
@@ -1,7 +1,7 @@
 package com.penglobe.server.domain.ledger;
 
 public enum LedgerReason {
-    WALK_ACTIVITY,
+    TRANSPORT_ACTIVITY,
     DIET_DAILY_SUCCESS,
     ATTENDANCE,
     QUIZ,

--- a/src/main/java/com/penglobe/server/service/TransportActivityService.java
+++ b/src/main/java/com/penglobe/server/service/TransportActivityService.java
@@ -1,16 +1,21 @@
 package com.penglobe.server.service;
 
+import com.penglobe.server.domain.ledger.LedgerReason;
+import com.penglobe.server.domain.ledger.PointsLedger;
 import com.penglobe.server.domain.transport.TransportActivity;
 import com.penglobe.server.domain.transport.TransportMode;
 import com.penglobe.server.domain.user.User;
+import com.penglobe.server.domain.user.UserCounters;
+import com.penglobe.server.repository.PointsLedgerRepository;
 import com.penglobe.server.repository.TransportActivityRepository;
+import com.penglobe.server.repository.UserCountersRepository;
+import com.penglobe.server.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service
@@ -18,6 +23,9 @@ import java.time.LocalDateTime;
 public class TransportActivityService {
 
     private final TransportActivityRepository activityRepository;
+    private final UserRepository userRepository;
+    private final UserCountersRepository userCountersRepository;
+    private final PointsLedgerRepository pointsLedgerRepository;
 
     // 이동 시작
     @Transactional
@@ -46,11 +54,41 @@ public class TransportActivityService {
         BigDecimal co2Kg = calculateCo2Saving(distanceM, activity.getMode());
         activity.setCo2Kg(co2Kg);
 
-        // TODO: 유저의 누적 절감량 업데이트
-        // TODO: 유저 포인트 지급 로직 추가
+        // ✅ 유저의 누적 절감량 업데이트
+        if (co2Kg.compareTo(BigDecimal.ZERO) > 0) {
+            UserCounters counters = userCountersRepository.findById(activity.getUser().getUserId())
+                    .orElseThrow(() -> new IllegalStateException("UserCounters를 찾을 수 없습니다."));
+
+            counters.setTotalDistanceCo2Kg(
+                    counters.getTotalDistanceCo2Kg().add(co2Kg)
+            );
+            userCountersRepository.save(counters);
+        }
+
+        // ✅ 포인트 지급 (1kg 절감량당 100 포인트)
+        int points = co2Kg.multiply(BigDecimal.valueOf(100))
+                .setScale(0, RoundingMode.FLOOR) // 소수점 버림
+                .intValue();
+
+        if (points > 0) {
+            User user = activity.getUser();
+
+            // 유저 보유 포인트 업데이트
+            user.setTotalPoint(user.getTotalPoint() + points);
+            userRepository.save(user);
+
+            // 포인트 적립 내역 저장
+            PointsLedger ledger = PointsLedger.builder()
+                    .user(user)
+                    .changeAmount(points)
+                    .reason(LedgerReason.TRANSPORT_ACTIVITY) // 🚩 교통 활동 적립 사유
+                    .build();
+            pointsLedgerRepository.save(ledger);
+        }
 
         return activityRepository.save(activity);
     }
+
 
     // CO₂ 절감량 계산 로직
     private BigDecimal calculateCo2Saving(int distanceM, TransportMode mode) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,31 @@
---=====================
---1. 기존 데이터 삭제
---====================
---DELETE FROM users;
-select * from users;
 
---======================
+-- ======================
 -- 1. User 더미 데이터
 -- =====================
--- INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, created_at, updated_at)
--- VALUES
---     ('USER', 'user1@example.com', 'hashed_pw1', 'Alice', 101, 100, NULL, NULL, true, NOW(), NOW()),
---     ('USER', 'user2@example.com', 'hashed_pw2', 'Bob', 102, 50, NULL, NULL, false, NOW(), NOW());
+-- 엔티티에 @CreationTimestamp가 있어도, Hibernate가 엔티티를 통해 INSERT할 때만 자동으로 채워짐.
+-- data.sql은 Hibernate/JPA를 거치지 않고 DB에 직접 실행되기 때문에 created_at, updated_at 안주면 null로 들어가 버림
 
+INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
+VALUES ('USER', 'user1@example.com', 'hashed_pw1', 'Alice', 101, 100, NULL, NULL, 1, NULL, NOW(), NOW());
 
+INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
+VALUES ('USER', 'user2@example.com', 'hashed_pw2', 'Bob', 102, 50, NULL, NULL, 0, NULL, NOW(), NOW());
+
+-- ======================
+-- 2. UserCounters 더미 데이터
+-- ======================
+-- user_id는 users 테이블의 PK(auto_increment)와 동일하게 맞춰야 함
+-- total_* 값은 모두 기본 0으로 시작
+INSERT INTO user_counters (user_id, total_distance_co2kg, total_diet_co2kg, total_survey_co2kg,
+                           attendance_total_days, attendance_streak_days, attendance_month_days,
+                           last_attendance_date, longest_attendance_streak,
+                           created_at, updated_at)
+VALUES
+    (1, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()), -- Alice용 카운터
+    (2, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()); -- Bob용 카운터
 
 -- =====================
--- 2. 설문조사 질문 더미 데이터
+-- 3. 설문조사 질문 더미 데이터
 -- =====================
 -- INSERT INTO survey_item (code, question, created_at, updated_at) VALUES
 --                                                                      ('분리배출', '오늘 재활용품(종이, 플라스틱, 캔 등)을 올바르게 분리배출 했나요?', NOW(), NOW()),
@@ -26,7 +36,7 @@ select * from users;
 --                                                                      ('새로운 시도', '오늘 환경을 위한 새로운 시도를 했나요?', NOW(), NOW());
 
 -- =====================
--- 3. 설문조사 응답별 탄소배출량 더미 데이터
+-- 4. 설문조사 응답별 탄소배출량 더미 데이터
 -- -- =====================
 -- INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
 --                                                                               (37, 1, 0.05, NOW(), NOW()),


### PR DESCRIPTION
## ✅ 작업 내용
- TransportActivityService.stopActivity() TODO 구현
- 유저의 UserCounters.totalDistanceCo2Kg 업데이트
- 절감량(kg) * 100 포인트 지급 로직 추가
- User.totalPoint 업데이트 및 PointsLedger 기록
- LedgerReason.TRANSPORT_ACTIVITY 적용
- data.sql 문 업데이트

## 🔗 관련 이슈
Closes #81 

## 🧪 테스트
- [ ] 로컬 실행 후 DB 반영 확인
- [ ] 포인트 적립 시 Ledger 기록 여부 확인

## 📝 기타
- 포인트 산정 시 소수점은 **버림(FLOOR)** 처리 (ex: 1.26kg → 126포인트)
- 정책 변경 시 반올림(HALF_UP) 적용 가능
-  data.sql과 application.propeties 업데이트 각자 확인 요망