### PR TITLE
✨ feat: 출석 로그 및 UserCounters 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/penglobe/server/domain/attendance/AttendanceLog.java
+++ b/src/main/java/com/penglobe/server/domain/attendance/AttendanceLog.java
@@ -1,0 +1,38 @@
+package com.penglobe.server.domain.attendance;
+
+import com.penglobe.server.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "attendance_logs",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "date"})
+)
+public class AttendanceLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long attendanceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttendanceType attendanceType;
+
+    @Column(name = "shown_at")
+    private LocalDate shownAt;
+}

--- a/src/main/java/com/penglobe/server/domain/attendance/AttendanceType.java
+++ b/src/main/java/com/penglobe/server/domain/attendance/AttendanceType.java
@@ -1,0 +1,8 @@
+package com.penglobe.server.domain.attendance;
+
+
+public enum AttendanceType {
+    TRANSPORT_ACTIVITY,
+    DIET,
+    SURVEY
+}

--- a/src/main/java/com/penglobe/server/domain/ledger/LedgerReason.java
+++ b/src/main/java/com/penglobe/server/domain/ledger/LedgerReason.java
@@ -2,10 +2,10 @@ package com.penglobe.server.domain.ledger;
 
 public enum LedgerReason {
     TRANSPORT_ACTIVITY,
-    DIET_DAILY_SUCCESS,
+    DIET,
     ATTENDANCE,
     QUIZ,
+    SURVEY,
     MISSION_REWARD,
-    SHOP_PURCHASE,
-    OTHER
+    SHOP_PURCHASE
 }

--- a/src/main/java/com/penglobe/server/repository/AttendanceLogRepository.java
+++ b/src/main/java/com/penglobe/server/repository/AttendanceLogRepository.java
@@ -1,0 +1,15 @@
+package com.penglobe.server.repository;
+
+import com.penglobe.server.domain.attendance.AttendanceLog;
+import com.penglobe.server.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Long> {
+
+    Optional<AttendanceLog> findByUserAndDate(User user, LocalDate date);
+
+    boolean existsByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/penglobe/server/repository/UserCountersRepository.java
+++ b/src/main/java/com/penglobe/server/repository/UserCountersRepository.java
@@ -1,8 +1,10 @@
 package com.penglobe.server.repository;
+
 import com.penglobe.server.domain.user.User;
 import com.penglobe.server.domain.user.UserCounters;
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.penglobe.server.dto.UserTotalScoreDTO;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserCountersRepository extends JpaRepository<UserCounters, Long> {
+
     @Query("SELECT uc.user FROM UserCounters uc WHERE uc.lastAttendanceDate >= :sevenDaysAgo")
     List<User> findUsersActiveSince(@Param("sevenDaysAgo") LocalDate sevenDaysAgo);
 
@@ -22,9 +25,44 @@ public interface UserCountersRepository extends JpaRepository<UserCounters, Long
     List<UserTotalScoreDTO> findUserTotalScores();
 
     @Query("SELECT SUM(COALESCE(uc.totalDistanceCo2Kg, 0) + COALESCE(uc.totalDietCo2Kg, 0) + COALESCE(uc.totalSurveyCo2Kg, 0)) " +
-           "FROM UserCounters uc WHERE uc.user.regionId = :regionId")
+            "FROM UserCounters uc WHERE uc.user.regionId = :regionId")
     Optional<BigDecimal> sumTotalCo2ByRegionId(@Param("regionId") Integer regionId);
+
     Optional<UserCounters> findByUserId(Long userId);
 
+    Optional<UserCounters> findByUser(User user);
+
+    // ================== 🔽 최적화된 벌크 업데이트 ================== //
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE UserCounters uc " +
+            "SET uc.totalDistanceCo2Kg = uc.totalDistanceCo2Kg + :co2Kg " +
+            "WHERE uc.user = :user")
+    int addDistanceCo2(@Param("user") User user, @Param("co2Kg") BigDecimal co2Kg);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE UserCounters uc " +
+            "SET uc.totalDietCo2Kg = uc.totalDietCo2Kg + :co2Kg " +
+            "WHERE uc.user = :user")
+    int addDietCo2(@Param("user") User user, @Param("co2Kg") BigDecimal co2Kg);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE UserCounters uc " +
+            "SET uc.totalSurveyCo2Kg = uc.totalSurveyCo2Kg + :co2Kg " +
+            "WHERE uc.user = :user")
+    int addSurveyCo2(@Param("user") User user, @Param("co2Kg") BigDecimal co2Kg);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE UserCounters uc " +
+            "SET uc.attendanceTotalDays = uc.attendanceTotalDays + 1, " +
+            "    uc.attendanceMonthDays = :monthDays, " +
+            "    uc.attendanceStreakDays = :streakDays, " +
+            "    uc.longestAttendanceStreak = GREATEST(uc.longestAttendanceStreak, :streakDays), " +
+            "    uc.lastAttendanceDate = :today " +
+            "WHERE uc.user = :user")
+    int updateAttendanceStats(@Param("user") User user,
+                              @Param("today") LocalDate today,
+                              @Param("streakDays") int streakDays,
+                              @Param("monthDays") int monthDays);
 
 }

--- a/src/main/java/com/penglobe/server/service/AttendanceLogService.java
+++ b/src/main/java/com/penglobe/server/service/AttendanceLogService.java
@@ -1,0 +1,67 @@
+package com.penglobe.server.service;
+
+import com.penglobe.server.domain.attendance.AttendanceLog;
+import com.penglobe.server.domain.attendance.AttendanceType;
+import com.penglobe.server.domain.user.User;
+import com.penglobe.server.domain.user.UserCounters;
+import com.penglobe.server.repository.AttendanceLogRepository;
+import com.penglobe.server.repository.UserCountersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceLogService {
+
+    private final AttendanceLogRepository attendanceLogRepository;
+    private final UserCountersRepository userCountersRepository;
+
+    @Transactional
+    public AttendanceLog markAttendance(User user, AttendanceType type) {
+        LocalDate today = LocalDate.now();
+
+        // 하루 1회만 인정
+        if (attendanceLogRepository.existsByUserAndDate(user, today)) {
+            throw new IllegalStateException("오늘 이미 출석이 등록되었습니다.");
+        }
+
+        // 출석 로그 저장
+        AttendanceLog log = AttendanceLog.builder()
+                .user(user)
+                .date(today)
+                .attendanceType(type)
+                .shownAt(today)
+                .build();
+        attendanceLogRepository.save(log);
+
+        // UserCounters 조회
+        UserCounters counters = userCountersRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("UserCounters 없음"));
+
+        // streak 계산
+        int streakDays = 1;
+        if (counters.getLastAttendanceDate() != null &&
+                counters.getLastAttendanceDate().plusDays(1).equals(today)) {
+            streakDays = counters.getAttendanceStreakDays() + 1;
+        }
+
+        // monthDays 계산
+        int monthDays;
+        if (counters.getLastAttendanceDate() != null &&
+                counters.getLastAttendanceDate().getMonth().equals(today.getMonth()) &&
+                counters.getLastAttendanceDate().getYear() == today.getYear()) {
+            monthDays = counters.getAttendanceMonthDays() + 1;
+        } else {
+            monthDays = 1; // 새 달이면 리셋
+        }
+
+        // 벌크 업데이트 실행
+        userCountersRepository.updateAttendanceStats(user, today, streakDays, monthDays);
+
+        return log;
+    }
+
+}

--- a/src/main/java/com/penglobe/server/service/TransportActivityService.java
+++ b/src/main/java/com/penglobe/server/service/TransportActivityService.java
@@ -1,5 +1,6 @@
 package com.penglobe.server.service;
 
+import com.penglobe.server.domain.attendance.AttendanceType;
 import com.penglobe.server.domain.ledger.LedgerReason;
 import com.penglobe.server.domain.ledger.PointsLedger;
 import com.penglobe.server.domain.transport.TransportActivity;
@@ -28,8 +29,11 @@ public class TransportActivityService {
     private final UserRepository userRepository;
     private final UserCountersRepository userCountersRepository;
     private final PointsLedgerRepository pointsLedgerRepository;
+    private final AttendanceLogService attendanceLogService;
 
-    // 이동 시작
+    /**
+     * 🚶 이동 시작
+     */
     @Transactional
     public TransportActivity startActivity(User user, TransportMode mode) {
         TransportActivity activity = TransportActivity.builder()
@@ -43,7 +47,9 @@ public class TransportActivityService {
         return activityRepository.save(activity);
     }
 
-    // 이동 종료 (거리, 경로 저장, CO₂ 절감량 계산)
+    /**
+     * 🏁 이동 종료 (거리, CO₂ 절감량, 포인트, 유저카운터, 출석 로그)
+     */
     @Transactional
     public TransportActivityDto stopActivity(Long transportId, int distanceM, String pathGeojson) {
         TransportActivity activity = activityRepository.findById(transportId)
@@ -52,7 +58,7 @@ public class TransportActivityService {
         activity.setEndTime(LocalDateTime.now());
         activity.setDistanceM(distanceM);
 
-        // 🚩 CO₂ 절감량
+        // 🚩 CO₂ 절감량 계산
         BigDecimal co2Kg = calculateCo2Saving(distanceM, activity.getMode());
         activity.setCo2Kg(co2Kg);
 
@@ -80,17 +86,27 @@ public class TransportActivityService {
             pointsLedgerRepository.save(ledger);
         }
 
+        // ✅ UserCounters에 환경걸음 누적 절감량 업데이트
+        userCountersRepository.addDistanceCo2(activity.getUser(), co2Kg);
+
+        // ✅ 출석 로그 (하루 1회만)
+        try {
+            attendanceLogService.markAttendance(activity.getUser(), AttendanceType.TRANSPORT_ACTIVITY);
+        } catch (IllegalStateException e) {
+            // 이미 오늘 출석이 있으면 무시
+        }
+
         activityRepository.save(activity);
 
-        // ✅ 여기서 DTO 조립
         return TransportActivityDto.fromEntity(activity, durationM, points);
     }
 
-
-
-    // CO₂ 절감량 계산 로직
+    /**
+     * 📊 CO₂ 절감량 계산 로직
+     */
     private BigDecimal calculateCo2Saving(int distanceM, TransportMode mode) {
-        BigDecimal km = BigDecimal.valueOf(distanceM).divide(BigDecimal.valueOf(1000), 4, RoundingMode.HALF_UP);
+        BigDecimal km = BigDecimal.valueOf(distanceM)
+                .divide(BigDecimal.valueOf(1000), 4, RoundingMode.HALF_UP);
 
         // 🚗 승용차 평균 배출량: 0.2 kg/km
         BigDecimal carCo2Kg = km.multiply(BigDecimal.valueOf(0.2));
@@ -104,5 +120,4 @@ public class TransportActivityService {
         return carCo2Kg.multiply(BigDecimal.valueOf(factor))
                 .setScale(2, RoundingMode.HALF_UP); // ✅ 소수점 둘째 자리까지
     }
-
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,91 +1,89 @@
-select * from users;
 -- ======================
 -- 1. User 더미 데이터
--- =====================
+-- ======================
 -- 엔티티에 @CreationTimestamp가 있어도, Hibernate가 엔티티를 통해 INSERT할 때만 자동으로 채워짐.
 -- data.sql은 Hibernate/JPA를 거치지 않고 DB에 직접 실행되기 때문에 created_at, updated_at 안주면 null로 들어가 버림
---
--- INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
--- VALUES ('USER', 'user1@example.com', 'hashed_pw1', 'Alice', 101, 100, NULL, NULL, 1, NULL, NOW(), NOW());
---
--- INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
--- VALUES ('USER', 'user2@example.com', 'hashed_pw2', 'Bob', 102, 50, NULL, NULL, 0, NULL, NOW(), NOW());
---
--- -- -- ======================
--- -- 2. UserCounters 더미 데이터
--- -- ======================
--- --user_id는 users 테이블의 PK(auto_increment)와 동일하게 맞춰야 함
--- --total_* 값은 모두 기본 0으로 시작
--- INSERT INTO user_counters (user_id, total_distance_co2kg, total_diet_co2kg, total_survey_co2kg,
---                            attendance_total_days, attendance_streak_days, attendance_month_days,
---                            last_attendance_date, longest_attendance_streak,
---                            created_at, updated_at)
--- VALUES
---     (1, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()), -- Alice용 카운터
---     (2, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()); -- Bob용 카운터
---
--- -- -- -- =====================
--- -- -- 3. 설문조사 질문 더미 데이터
--- -- -- =====================
--- delete from survey_item;
--- INSERT INTO survey_item (code, question, created_at, updated_at) VALUES
---                                                                      ('분리배출', '오늘 재활용품(종이, 플라스틱, 캔 등)을 올바르게 분리배출 했나요?', NOW(), NOW()),
---                                                                      ('일회용품', '오늘 일회용품을 얼마나 사용했나요?', NOW(), NOW()),
---                                                                      ('종이 타월 사용', '오늘 종이 타월을 얼마나 사용했나요?', NOW(), NOW()),
---                                                                      ('음식물 쓰레기', '오늘 음식물 쓰레기를 줄였나요?', NOW(), NOW()),
---                                                                      ('에너지 절약', '오늘 불필요한 전기를 끄거나 절약했나요?', NOW(), NOW()),
---                                                                      ('새로운 시도', '오늘 환경을 위한 새로운 시도를 했나요?', NOW(), NOW());
---
--- -- =====================
--- -- 4. 설문조사 응답별 탄소배출량 더미 데이터
--- -- -- =====================
-delete from survey_option;
+
+INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
+VALUES ('USER', 'user1@example.com', 'hashed_pw1', 'Alice', 101, 100, NULL, NULL, 1, NULL, NOW(), NOW());
+
+INSERT INTO users (type, email, password_hash, nickname, region_id, total_point, profile_id, kakao_id, is_profile_complete, last_week_rank, created_at, updated_at)
+VALUES ('USER', 'user2@example.com', 'hashed_pw2', 'Bob', 102, 50, NULL, NULL, 0, NULL, NOW(), NOW());
+
+-- ======================
+-- 2. UserCounters 더미 데이터
+-- ======================
+-- user_id는 users 테이블의 PK(auto_increment)와 동일하게
+-- total_* 값은 모두 기본 0으로 시작
+INSERT INTO user_counters (user_id, total_distance_co2kg, total_diet_co2kg, total_survey_co2kg,
+                           attendance_total_days, attendance_streak_days, attendance_month_days,
+                           last_attendance_date, longest_attendance_streak,
+                           created_at, updated_at)
+VALUES
+    (1, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()), -- Alice용 카운터
+    (2, 0, 0, 0, 0, 0, 0, NULL, 0, NOW(), NOW()); -- Bob용 카운터
+
+-- =====================
+-- 3. 설문조사 질문 더미 데이터
+-- =====================
+DELETE FROM survey_item;
+INSERT INTO survey_item (code, question, created_at, updated_at) VALUES
+                                                                     ('분리배출', '오늘 재활용품(종이, 플라스틱, 캔 등)을 올바르게 분리배출 했나요?', NOW(), NOW()),
+                                                                     ('일회용품', '오늘 일회용품을 얼마나 사용했나요?', NOW(), NOW()),
+                                                                     ('종이 타월 사용', '오늘 종이 타월을 얼마나 사용했나요?', NOW(), NOW()),
+                                                                     ('음식물 쓰레기', '오늘 음식물 쓰레기를 줄였나요?', NOW(), NOW()),
+                                                                     ('에너지 절약', '오늘 불필요한 전기를 끄거나 절약했나요?', NOW(), NOW()),
+                                                                     ('새로운 시도', '오늘 환경을 위한 새로운 시도를 했나요?', NOW(), NOW());
+
+-- =====================
+-- 4. 설문조사 응답별 탄소배출량 더미 데이터
+-- =====================
+-- 분리배출
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (1, '모두 잘 했다', 0.05, NOW(), NOW()),
-                                                                              (1, '일부만 했다', 0.02, NOW(), NOW()),
-                                                                              (1, '하지 못 했다', 0, NOW(), NOW());
+                                                                                     (1, '모두 잘 했다', 0.05, NOW(), NOW()),
+                                                                                     (1, '일부만 했다', 0.02, NOW(), NOW()),
+                                                                                     (1, '하지 못 했다', 0, NOW(), NOW());
 
 -- 일회용품
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (2, '0회', 0.24, NOW(), NOW()),
-                                                                              (2, '1~2회', 0.12, NOW(), NOW()),
-                                                                              (2, '3회 이상', 0, NOW(), NOW());
+                                                                                     (2, '0회', 0.24, NOW(), NOW()),
+                                                                                     (2, '1~2회', 0.12, NOW(), NOW()),
+                                                                                     (2, '3회 이상', 0, NOW(), NOW());
 
 -- 종이 타월 사용
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (3, '0장 사용', 0.15, NOW(), NOW()),
-                                                                              (3, '1~2장 사용', 0.05, NOW(), NOW()),
-                                                                              (3,
-                                                                               '3장 이상 사용', 0, NOW(), NOW());
+                                                                                     (3, '0장 사용', 0.15, NOW(), NOW()),
+                                                                                     (3, '1~2장 사용', 0.05, NOW(), NOW()),
+                                                                                     (3, '3장 이상 사용', 0, NOW(), NOW());
 
 -- 음식물 쓰레기
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (4, '예', 0, NOW(), NOW()),
-                                                                              (4, '아니오', 0.02, NOW(), NOW());
+                                                                                     (4, '예', 0, NOW(), NOW()),
+                                                                                     (4, '아니오', 0.02, NOW(), NOW());
 
 -- 에너지 절약
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (5, '모두 껐다', 0.05, NOW(), NOW()),
-                                                                              (5, '일부만 껐다', 0.05, NOW(), NOW()),
-                                                                              (5, '꺼두지 않았다', 0, NOW(), NOW());
+                                                                                     (5, '모두 껐다', 0.05, NOW(), NOW()),
+                                                                                     (5, '일부만 껐다', 0.05, NOW(), NOW()),
+                                                                                     (5, '꺼두지 않았다', 0, NOW(), NOW());
 
 -- 새로운 시도
 INSERT INTO survey_option (survey_item_id, value, co2kg, created_at, updated_at) VALUES
-                                                                              (6, '뜻깊은 실천을 했다', 0, NOW(), NOW()),
-                                                                              (6,
-                                                                            '조금 실천했다', 0, NOW(), NOW()),
-                                                                              (6, '하지 않았다', 0, NOW(), NOW());
+                                                                                     (6, '뜻깊은 실천을 했다', 0, NOW(), NOW()),
+                                                                                     (6, '조금 실천했다', 0, NOW(), NOW()),
+                                                                                     (6, '하지 않았다', 0, NOW(), NOW());
 
-delete from quiz;
-ALTER TABLE quiz AUTO_INCREMENT = 1;
+-- =====================
+-- 5. 퀴즈 더미 데이터
+-- =====================
 INSERT INTO quiz (question, is_answer_true, created_at, updated_at) VALUES
-                                                ('태양은 동쪽에서 뜬다.', TRUE, NOW(),NOW()),
-                                                ('물은 100도에서 끓는다.', TRUE,NOW(),NOW()),
-                                                ('사자는 초식동물이다.', FALSE, NOW(),NOW()),
-                                                ('지구는 평평하다.', FALSE, NOW(),NOW()),
-                                                ('컴퓨터는 계산기와 같다.', TRUE, NOW(),NOW()),
-                                                ('바나나는 나무에서 자란다.', FALSE, NOW(),NOW()),
-                                                ('달은 스스로 빛을 낸다.', FALSE, NOW(),NOW()),
-                                                ('인체의 뼈는 206개이다.', TRUE, NOW(),NOW()),
-                                                ('전자레인지로 금속을 데울 수 있다.', FALSE, NOW(),NOW()),
-                                                ('코끼리는 포유류이다.', TRUE, NOW(),NOW());
+                                                                        ('태양은 동쪽에서 뜬다.', TRUE, NOW(),NOW()),
+                                                                        ('물은 100도에서 끓는다.', TRUE,NOW(),NOW()),
+                                                                        ('사자는 초식동물이다.', FALSE, NOW(),NOW()),
+                                                                        ('지구는 평평하다.', FALSE, NOW(),NOW()),
+                                                                        ('컴퓨터는 계산기와 같다.', TRUE, NOW(),NOW()),
+                                                                        ('바나나는 나무에서 자란다.', FALSE, NOW(),NOW()),
+                                                                        ('달은 스스로 빛을 낸다.', FALSE, NOW(),NOW()),
+                                                                        ('인체의 뼈는 206개이다.', TRUE, NOW(),NOW()),
+                                                                        ('전자레인지로 금속을 데울 수 있다.', FALSE, NOW(),NOW()),
+                                                                        ('코끼리는 포유류이다.', TRUE, NOW(),NOW());


### PR DESCRIPTION
## ✅ 작업 내용
* 하루 1회 출석 기록 (AttendanceLog) 저장
* UserCounters 벌크 업데이트 최적화
* TransportActivity와 출석 시스템 연동

---

## 🔗 관련 이슈
Closes #88 
---

## 🧪 테스트
* [x] 로컬 실행 확인
* [x] TransportActivity API 호출 → 출석/카운터 반영 확인

---

## 📝 기타
* 추후 출석 포인트 지급 로직(`PointsLedger`)도 추가 필요