### PR TITLE
🐛 bugfix: 출석 중복 시 rollback 발생 문제 수정 (boolean 반환으로 변경)

### DIFF
--- a/src/main/java/com/penglobe/server/repository/UserCountersRepository.java
+++ b/src/main/java/com/penglobe/server/repository/UserCountersRepository.java
@@ -65,4 +65,5 @@ public interface UserCountersRepository extends JpaRepository<UserCounters, Long
                               @Param("streakDays") int streakDays,
                               @Param("monthDays") int monthDays);
 
+
 }

--- a/src/main/java/com/penglobe/server/service/AttendanceLogService.java
+++ b/src/main/java/com/penglobe/server/service/AttendanceLogService.java
@@ -19,16 +19,20 @@ public class AttendanceLogService {
     private final AttendanceLogRepository attendanceLogRepository;
     private final UserCountersRepository userCountersRepository;
 
+    /**
+     * 출석 등록 시도
+     * @return true = 오늘 첫 출석, false = 이미 출석한 경우
+     */
     @Transactional
-    public AttendanceLog markAttendance(User user, AttendanceType type) {
+    public boolean markAttendance(User user, AttendanceType type) {
         LocalDate today = LocalDate.now();
 
         // 하루 1회만 인정
         if (attendanceLogRepository.existsByUserAndDate(user, today)) {
-            throw new IllegalStateException("오늘 이미 출석이 등록되었습니다.");
+            return false; // 이미 출석 기록 있음 → 무시
         }
 
-        // 출석 로그 저장
+        // 새로운 출석 로그 저장
         AttendanceLog log = AttendanceLog.builder()
                 .user(user)
                 .date(today)
@@ -55,13 +59,12 @@ public class AttendanceLogService {
                 counters.getLastAttendanceDate().getYear() == today.getYear()) {
             monthDays = counters.getAttendanceMonthDays() + 1;
         } else {
-            monthDays = 1; // 새 달이면 리셋
+            monthDays = 1; // 새 달이면 초기화
         }
 
         // 벌크 업데이트 실행
         userCountersRepository.updateAttendanceStats(user, today, streakDays, monthDays);
 
-        return log;
+        return true; // 오늘 첫 출석 인정
     }
-
 }

--- a/src/main/java/com/penglobe/server/service/TransportActivityService.java
+++ b/src/main/java/com/penglobe/server/service/TransportActivityService.java
@@ -14,6 +14,7 @@ import com.penglobe.server.repository.UserCountersRepository;
 import com.penglobe.server.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -21,6 +22,7 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class TransportActivityService {
@@ -89,11 +91,12 @@ public class TransportActivityService {
         // ✅ UserCounters에 환경걸음 누적 절감량 업데이트
         userCountersRepository.addDistanceCo2(activity.getUser(), co2Kg);
 
-        // ✅ 출석 로그 (하루 1회만)
-        try {
-            attendanceLogService.markAttendance(activity.getUser(), AttendanceType.TRANSPORT_ACTIVITY);
-        } catch (IllegalStateException e) {
-            // 이미 오늘 출석이 있으면 무시
+        // 출석 로그 시도 (하루 1회만 인정)
+        boolean newAttendance = attendanceLogService.markAttendance(activity.getUser(), AttendanceType.TRANSPORT_ACTIVITY);
+        if (newAttendance) {
+            log.info("오늘 첫 출석 인정 ✅");
+        } else {
+            log.info("이미 오늘 출석함 → 무시");
         }
 
         activityRepository.save(activity);


### PR DESCRIPTION
## ✅ 작업 내용
- 출석 중복 시 예외 대신 boolean 반환으로 변경
- 포인트 적립 로직은 무조건 정상 반영되도록 수정
- UserCounters 업데이트 로직은 기존대로 유지

## 🔗 관련 이슈
Closes #91 

## 🧪 테스트
- [x] 오늘 첫 출석 시 출석 로그 & 포인트 정상 반영
- [x] 같은 날 재출석 시 포인트는 적립되지만 출석은 무시됨
- [x] rollback 발생하지 않음 확인

## 📝 기타
- 서비스 호출부에서 `boolean`으로 출석 성공/중복 여부 확인 가능
