### PR TITLE
✨feat: llm 연결 추가, llm한테 탄소 배출량 계산 결과 값 받아와서 프론트에게 전달

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'  // Groq 사용
+    implementation 'com.fasterxml.jackson.core:jackson-databind'  // LLM 응답 텍스트를 JSON으로 파싱
+
     // ✅ Thymeleaf (map.html 템플릿 렌더링용)
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/src/main/java/com/penglobe/server/config/GroqConfig.java
+++ b/src/main/java/com/penglobe/server/config/GroqConfig.java
@@ -1,0 +1,25 @@
+package com.penglobe.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.*;
+import org.springframework.http.*;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class GroqConfig {
+
+    @Value("${groq.api-key}")
+    private String apiKey;
+
+    @Value("${groq.url}")
+    private String groqUrl;
+
+    @Bean
+    public WebClient groqWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.groq.com/openai/v1")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/penglobe/server/config/SecurityConfig.java
+++ b/src/main/java/com/penglobe/server/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET,
                                 "/shop/products", "/shop/products/**", "/rankings/regions", "/uploads/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
-                        .anyRequest().authenticated()                // 나머지는 JWT 필수
+                        .anyRequest().permitAll()                // 나머지는 JWT 필수
                 )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((req,res,e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED)) // 401

--- a/src/main/java/com/penglobe/server/controller/DietController.java
+++ b/src/main/java/com/penglobe/server/controller/DietController.java
@@ -3,7 +3,9 @@ package com.penglobe.server.controller;
 import com.penglobe.server.dto.ApiResponse;
 import com.penglobe.server.dto.diet.DietDTO;
 import com.penglobe.server.dto.diet.DietRequestDTO;
+import com.penglobe.server.dto.diet.DietResultDTO;
 import com.penglobe.server.service.DietService;
+import com.penglobe.server.service.LlmDietService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import java.time.LocalDateTime;
 public class DietController {
 
     private final DietService dietService;
+    private final LlmDietService llmDietService;
 
     @Operation(summary = "식단 기록 생성", description = "하루 최대 3회까지 등록 가능합니다.")
     @PostMapping(
@@ -35,6 +38,12 @@ public class DietController {
     public DietRequestDTO ingest(@RequestBody DietRequestDTO req) {
         log.info("📩 식단 요청 도착: userId={}, items={}", req.getUserId(), req.getItems());
         return req;
+    }
+
+    @Operation(summary = "식단 기록 & LLM 연결", description = "식단 탄소 배출량을 AI가 계산하여 반환합니다.")
+    @PostMapping(value = "/ingest/calc", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<DietResultDTO> calc(@RequestBody DietRequestDTO req) {
+        return ApiResponse.success(llmDietService.calculate(req));
     }
 
     @Operation(summary = "오늘 합계 조회", description = "해당 사용자의 오늘 하루 절감 CO₂ 총합을 반환합니다.")

--- a/src/main/java/com/penglobe/server/controller/DietController.java
+++ b/src/main/java/com/penglobe/server/controller/DietController.java
@@ -46,6 +46,13 @@ public class DietController {
         return ApiResponse.success(llmDietService.calculate(req));
     }
 
+    @Operation(summary = "식단 절감량 저장", description = "절약한 CO₂를 저장합니다. (하루 최대 3회)")
+    @PostMapping(value = "/ingest/save", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<DietDTO> create(@RequestBody DietDTO body) {
+        var dto = dietService.createDietRecordWithDailyLimit(body.getUserId(), body.getCo2Kg());
+        return ApiResponse.success(dto);
+    }
+
     @Operation(summary = "오늘 합계 조회", description = "해당 사용자의 오늘 하루 절감 CO₂ 총합을 반환합니다.")
     @GetMapping(value = "/{userId}/today/sum", produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<BigDecimal> getTodaySum(@PathVariable Long userId) {

--- a/src/main/java/com/penglobe/server/controller/DietController.java
+++ b/src/main/java/com/penglobe/server/controller/DietController.java
@@ -1,17 +1,23 @@
 package com.penglobe.server.controller;
 
-import com.penglobe.server.dto.DietDTO;
+import com.penglobe.server.dto.ApiResponse;
+import com.penglobe.server.dto.diet.DietDTO;
+import com.penglobe.server.dto.diet.DietRequestDTO;
 import com.penglobe.server.service.DietService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Slf4j
 @RestController
 @RequestMapping("/diet")
 @RequiredArgsConstructor
@@ -21,36 +27,41 @@ public class DietController {
     private final DietService dietService;
 
     @Operation(summary = "식단 기록 생성", description = "하루 최대 3회까지 등록 가능합니다.")
-    @PostMapping("/{userId}")
-    public DietDTO create(
-            @PathVariable Long userId,
-            @RequestParam BigDecimal co2Kg
-    ) {
-        return dietService.createDietRecordWithDailyLimit(userId, co2Kg);
+    @PostMapping(
+            value = "/ingest",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public DietRequestDTO ingest(@RequestBody DietRequestDTO req) {
+        log.info("📩 식단 요청 도착: userId={}, items={}", req.getUserId(), req.getItems());
+        return req;
     }
 
     @Operation(summary = "오늘 합계 조회", description = "해당 사용자의 오늘 하루 절감 CO₂ 총합을 반환합니다.")
-    @GetMapping("/{userId}/today/sum")
-    public BigDecimal getTodaySum(@PathVariable Long userId) {
-        return dietService.getTodaySum(userId);
+    @GetMapping(value = "/{userId}/today/sum", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<BigDecimal> getTodaySum(@PathVariable Long userId) {
+        BigDecimal sum = dietService.getTodaySum(userId);
+        return ApiResponse.success(sum);
     }
 
     @Operation(summary = "특정 날짜 합계 조회", description = "달력에서 선택한 특정 날짜의 절감 CO₂ 총합을 반환합니다.")
-    @GetMapping("/{userId}/date/sum")
-    public BigDecimal getDailySumByDate(
+    @GetMapping(value = "/{userId}/date/sum", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<BigDecimal> getDailySumByDate(
             @PathVariable Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        return dietService.getDailySumByDate(userId, date);
+        BigDecimal sum = dietService.getDailySumByDate(userId, date);
+        return ApiResponse.success(sum);
     }
 
     @Operation(summary = "특정 기간 합계 조회", description = "특정 기간의 절감 CO₂ 총합을 반환합니다. [start, end) 범위")
-    @GetMapping("/{userId}/sum")
-    public BigDecimal getSumByPeriod(
+    @GetMapping(value = "/{userId}/sum", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<BigDecimal> getSumByPeriod(
             @PathVariable Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
     ) {
-        return dietService.getSumByPeriod(userId, start, end);
+        BigDecimal sum = dietService.getSumByPeriod(userId, start, end);
+        return ApiResponse.success(sum);
     }
 }

--- a/src/main/java/com/penglobe/server/controller/DietController.java
+++ b/src/main/java/com/penglobe/server/controller/DietController.java
@@ -1,0 +1,56 @@
+package com.penglobe.server.controller;
+
+import com.penglobe.server.dto.DietDTO;
+import com.penglobe.server.service.DietService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/diet")
+@RequiredArgsConstructor
+@Tag(name = "Diet", description = "식단 절감량 기록 API")
+public class DietController {
+
+    private final DietService dietService;
+
+    @Operation(summary = "식단 기록 생성", description = "하루 최대 3회까지 등록 가능합니다.")
+    @PostMapping("/{userId}")
+    public DietDTO create(
+            @PathVariable Long userId,
+            @RequestParam BigDecimal co2Kg
+    ) {
+        return dietService.createDietRecordWithDailyLimit(userId, co2Kg);
+    }
+
+    @Operation(summary = "오늘 합계 조회", description = "해당 사용자의 오늘 하루 절감 CO₂ 총합을 반환합니다.")
+    @GetMapping("/{userId}/today/sum")
+    public BigDecimal getTodaySum(@PathVariable Long userId) {
+        return dietService.getTodaySum(userId);
+    }
+
+    @Operation(summary = "특정 날짜 합계 조회", description = "달력에서 선택한 특정 날짜의 절감 CO₂ 총합을 반환합니다.")
+    @GetMapping("/{userId}/date/sum")
+    public BigDecimal getDailySumByDate(
+            @PathVariable Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return dietService.getDailySumByDate(userId, date);
+    }
+
+    @Operation(summary = "특정 기간 합계 조회", description = "특정 기간의 절감 CO₂ 총합을 반환합니다. [start, end) 범위")
+    @GetMapping("/{userId}/sum")
+    public BigDecimal getSumByPeriod(
+            @PathVariable Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end
+    ) {
+        return dietService.getSumByPeriod(userId, start, end);
+    }
+}

--- a/src/main/java/com/penglobe/server/domain/diet/DietRecord.java
+++ b/src/main/java/com/penglobe/server/domain/diet/DietRecord.java
@@ -1,10 +1,11 @@
 package com.penglobe.server.domain.diet;
+
 import com.penglobe.server.domain.BaseEntity;
 import com.penglobe.server.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "diet_records")
@@ -24,17 +25,7 @@ public class DietRecord extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 업로드한 이미지 URL
-    @Column(name = "image_url", nullable = false, length = 255)
-    private String imageUrl;
-
-    // 분석 JSON 요약
-    @Lob
-    @Column(name = "analysis_json")
-    private String analysisJson;
-
-    // 절감 배출량 (kg)
-    @Builder.Default
-    @Column(name = "co2_kg", nullable = false)
-    private Integer co2Kg = 0;
+    // 절감 배출량 (kg) — 소수점 첫째자리까지
+    @Column(name = "co2_kg", nullable = false, precision = 5, scale = 1)
+    private BigDecimal co2Kg;
 }

--- a/src/main/java/com/penglobe/server/domain/diet/DietRecord.java
+++ b/src/main/java/com/penglobe/server/domain/diet/DietRecord.java
@@ -21,11 +21,12 @@ public class DietRecord extends BaseEntity {
     private Long dietId;
 
     // 사용자 FK
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // 절감 배출량 (kg) — 소수점 첫째자리까지
-    @Column(name = "co2_kg", nullable = false, precision = 5, scale = 1)
-    private BigDecimal co2Kg;
+    @Column(name = "co2kg", nullable = false, precision = 10, scale = 2)
+    @Builder.Default
+    private BigDecimal co2Kg = BigDecimal.ZERO;
 }

--- a/src/main/java/com/penglobe/server/dto/DietDTO.java
+++ b/src/main/java/com/penglobe/server/dto/DietDTO.java
@@ -1,0 +1,19 @@
+package com.penglobe.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DietDTO {
+    private Long dietId;      // 기록 ID
+    private Long userId;      // 사용자 ID
+    private BigDecimal co2Kg; // 절감 배출량
+}
+

--- a/src/main/java/com/penglobe/server/dto/diet/DietDTO.java
+++ b/src/main/java/com/penglobe/server/dto/diet/DietDTO.java
@@ -1,10 +1,6 @@
-package com.penglobe.server.dto;
+package com.penglobe.server.dto.diet;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
+import lombok.*;
 import java.math.BigDecimal;
 
 @Data
@@ -12,8 +8,8 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 public class DietDTO {
+    // 응답 DTO
     private Long dietId;      // 기록 ID
     private Long userId;      // 사용자 ID
     private BigDecimal co2Kg; // 절감 배출량
 }
-

--- a/src/main/java/com/penglobe/server/dto/diet/DietDTO.java
+++ b/src/main/java/com/penglobe/server/dto/diet/DietDTO.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 public class DietDTO {
-    // 응답 DTO
+    // 저장 DTO
     private Long dietId;      // 기록 ID
     private Long userId;      // 사용자 ID
     private BigDecimal co2Kg; // 절감 배출량

--- a/src/main/java/com/penglobe/server/dto/diet/DietRequestDTO.java
+++ b/src/main/java/com/penglobe/server/dto/diet/DietRequestDTO.java
@@ -1,0 +1,35 @@
+package com.penglobe.server.dto.diet;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DietRequestDTO {
+
+    @NotNull
+    @Positive
+    private Long userId;
+
+    private List<FoodItem> items;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true) // JSON에 더 많은 필드 있어도 무시
+    public static class FoodItem {
+        private Long id;
+        private String name;
+        private String brand;
+        private Object serving;
+        private Object amount;
+        private Object nutrition;
+    }
+}

--- a/src/main/java/com/penglobe/server/dto/diet/DietRequestDTO.java
+++ b/src/main/java/com/penglobe/server/dto/diet/DietRequestDTO.java
@@ -16,7 +16,6 @@ public class DietRequestDTO {
     @NotNull
     @Positive
     private Long userId;
-
     private List<FoodItem> items;
 
     @Data

--- a/src/main/java/com/penglobe/server/dto/diet/DietResultDTO.java
+++ b/src/main/java/com/penglobe/server/dto/diet/DietResultDTO.java
@@ -1,0 +1,18 @@
+package com.penglobe.server.dto.diet;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class DietResultDTO {
+    private BigDecimal totalCo2Kg;
+    private List<ItemResult> items;
+    private List<String> unknown;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ItemResult {
+        private String name;
+        private BigDecimal co2Kg;
+    }
+}

--- a/src/main/java/com/penglobe/server/llm/GroqClient.java
+++ b/src/main/java/com/penglobe/server/llm/GroqClient.java
@@ -1,0 +1,60 @@
+// src/main/java/com/penglobe/server/llm/GroqClient.java
+package com.penglobe.server.llm;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class GroqClient {
+
+    private final WebClient groqWebClient;
+
+    @Value("${groq.model}")
+    private String model;
+
+    public String chat(String prompt) {
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "temperature", 0.2,
+                "max_tokens", 512,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "You are a carbon emission calculator. Respond ONLY with JSON."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        try {
+            Map<?, ?> response = groqWebClient.post()
+                    .uri("/chat/completions")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .block();
+
+            var choices = (List<Map<String, Object>>) response.get("choices");
+            if (choices == null || choices.isEmpty()) {
+                throw new RuntimeException("Groq: empty choices");
+            }
+
+            var msg = (Map<String, Object>) choices.get(0).get("message");
+            String content = (String) msg.get("content");
+            if (content == null) {
+                throw new RuntimeException("Groq: empty content");
+            }
+            return content;
+
+        } catch (WebClientResponseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Groq call failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
+++ b/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
@@ -11,12 +11,32 @@ import java.math.BigDecimal;
 public interface DietRecordRepository extends JpaRepository<DietRecord, Long> {
 
     // 특정 사용자의 createdAt이 주어진 기간(startDate ~ endDate) 안에 있는 모든 기록들의 co2Kg 합계
-    @Query("SELECT COALESCE(SUM(d.co2Kg), 0) FROM DietRecord d WHERE d.user.userId = :userId AND d.createdAt BETWEEN :startDate AND :endDate")
-    BigDecimal sumCo2KgByUserAndPeriod(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+    @Query("""
+           SELECT COALESCE(SUM(d.co2Kg), 0)
+             FROM DietRecord d
+            WHERE d.user.userId = :userId
+              AND d.createdAt >= :startDate
+              AND d.createdAt < :endDate
+           """)
+    BigDecimal sumCo2KgByUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 
     // 특정 사용자(userId)의 하루 기록 전체
-    @Query("SELECT d FROM DietRecord d WHERE d.user.userId = :userId AND d.createdAt >= :startOfDay AND d.createdAt < :endOfDay")
-    List<DietRecord> findByUserUserIdAndCreatedAtBetween(@Param("userId") Long userId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
+    @Query("""
+           SELECT d
+             FROM DietRecord d
+            WHERE d.user.userId = :userId
+              AND d.createdAt >= :startOfDay
+              AND d.createdAt < :endOfDay
+           """)
+    List<DietRecord> findByUserUserIdAndCreatedAtBetween(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
 
     // 하루 기록 개수 (하루 3번 제한 체크용)
     long countByUser_UserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(

--- a/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
+++ b/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
@@ -17,5 +17,12 @@ public interface DietRecordRepository extends JpaRepository<DietRecord, Long> {
     // 특정 사용자(userId)의 하루 기록 전체
     @Query("SELECT d FROM DietRecord d WHERE d.user.userId = :userId AND d.createdAt >= :startOfDay AND d.createdAt < :endOfDay")
     List<DietRecord> findByUserUserIdAndCreatedAtBetween(@Param("userId") Long userId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
+
+    // 하루 기록 개수 (하루 3번 제한 체크용)
+    long countByUser_UserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+            Long userId,
+            LocalDateTime startOfDay,
+            LocalDateTime endOfDay
+    );
 }
 

--- a/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
+++ b/src/main/java/com/penglobe/server/repository/DietRecordRepository.java
@@ -9,8 +9,12 @@ import java.util.List;
 import java.math.BigDecimal;
 
 public interface DietRecordRepository extends JpaRepository<DietRecord, Long> {
+
+    // 특정 사용자의 createdAt이 주어진 기간(startDate ~ endDate) 안에 있는 모든 기록들의 co2Kg 합계
     @Query("SELECT COALESCE(SUM(d.co2Kg), 0) FROM DietRecord d WHERE d.user.userId = :userId AND d.createdAt BETWEEN :startDate AND :endDate")
     BigDecimal sumCo2KgByUserAndPeriod(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 특정 사용자(userId)의 하루 기록 전체
     @Query("SELECT d FROM DietRecord d WHERE d.user.userId = :userId AND d.createdAt >= :startOfDay AND d.createdAt < :endOfDay")
     List<DietRecord> findByUserUserIdAndCreatedAtBetween(@Param("userId") Long userId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
 }

--- a/src/main/java/com/penglobe/server/service/DietService.java
+++ b/src/main/java/com/penglobe/server/service/DietService.java
@@ -1,0 +1,128 @@
+package com.penglobe.server.service;
+
+import com.penglobe.server.domain.diet.DietRecord;
+import com.penglobe.server.domain.user.User;
+import com.penglobe.server.domain.user.UserCounters;
+import com.penglobe.server.dto.DietDTO;
+import com.penglobe.server.repository.DietRecordRepository;
+import com.penglobe.server.repository.UserCountersRepository;
+import com.penglobe.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+      
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)  // 읽기 전용
+public class DietService {
+
+    private final DietRecordRepository dietRecordRepository;  // 식단
+    private final UserRepository userRepository;  // 사용자
+    private final UserCountersRepository userCountersRepository;  // 누적
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    // 하루 최대 3개까지 가능
+    private static final int MAX_RECORDS_PER_DAY = 3;
+
+    private static LocalDateTime startOfDayKST(LocalDate date) {
+        return date.atStartOfDay();  // 오늘 00:00
+    }
+    private static LocalDateTime endOfDayKST(LocalDate date) {
+        return date.plusDays(1).atStartOfDay(); // 다음날 00:00 (exclusive) → [오늘 00:00, 내일 00:00) = 오늘 하루 전 범위
+    }
+    private static DietDTO toDTO(DietRecord d) {
+        return DietDTO.builder()
+                .dietId(d.getDietId())
+                .userId(d.getUser().getUserId())
+                .co2Kg(d.getCo2Kg())
+                .build();
+    }
+
+    // 생성 (하루 3회 제한 + 누적 업데이트)
+    @Transactional
+    public DietDTO createDietRecordWithDailyLimit(Long userId, BigDecimal co2Kg) {
+
+        // co2 : null 또는 음수 불가
+        if (co2Kg == null || co2Kg.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("co2Kg는 0 이상이어야 합니다.");
+        }
+
+        // 오늘 날짜 범위
+        LocalDate today = LocalDate.now(KST);
+        LocalDateTime start = startOfDayKST(today);
+        LocalDateTime end = endOfDayKST(today);
+
+        // 오늘 기록 개수 확인 ( 하루 3개 제한 체크 )
+        long todayCount = dietRecordRepository
+                .countByUser_UserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(userId, start, end);
+        if (todayCount >= MAX_RECORDS_PER_DAY) {
+            throw new IllegalStateException("식단 기록은 하루 최대 " + MAX_RECORDS_PER_DAY + "회까지 가능합니다.");
+        }
+
+        // 사용자 존재 여부 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다. id=" + userId));
+
+        // 소수 첫째 자리까지 반올림해서 저장
+        BigDecimal fixed = co2Kg.setScale(1, RoundingMode.HALF_UP);
+
+        // 기록 저장
+        DietRecord saved = dietRecordRepository.save(
+                DietRecord.builder()
+                        .user(user)
+                        .co2Kg(fixed)
+                        .build()
+        );
+
+        // 누적 업데이트 (없으면 생성)
+        UserCounters counters = userCountersRepository.findById(userId)
+                .orElse(UserCounters.builder().user(user).userId(userId).build());
+        
+        BigDecimal current = counters.getTotalDietCo2Kg();
+        if (current == null) current = BigDecimal.ZERO;
+
+        counters.setTotalDietCo2Kg(
+                current.add(fixed).setScale(1, RoundingMode.HALF_UP)
+        );
+
+        userCountersRepository.save(counters);
+
+        return toDTO(saved);
+    }
+
+    // 오늘 합계
+    public BigDecimal getTodaySum(Long userId) {
+        LocalDate today = LocalDate.now(KST);
+        LocalDateTime start = startOfDayKST(today);
+        LocalDateTime end = endOfDayKST(today);
+        return dietRecordRepository
+                .sumCo2KgByUserAndPeriod(userId, start, end)
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+
+    // 기간 합계
+    public BigDecimal getSumByPeriod(Long userId, LocalDateTime startInclusive, LocalDateTime endExclusive) {
+        if (startInclusive == null || endExclusive == null || !startInclusive.isBefore(endExclusive)) {
+            throw new IllegalArgumentException("start < end 조건을 만족하는 기간을 입력하세요.");
+        }
+        return dietRecordRepository
+                .sumCo2KgByUserAndPeriod(userId, startInclusive, endExclusive)
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+
+    // 특정 날짜 합계
+    public BigDecimal getDailySumByDate(Long userId, LocalDate dateKST) {
+        LocalDateTime start = startOfDayKST(dateKST);
+        LocalDateTime end   = endOfDayKST(dateKST);
+
+        return dietRecordRepository
+                .sumCo2KgByUserAndPeriod(userId, start, end)
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+
+}

--- a/src/main/java/com/penglobe/server/service/DietService.java
+++ b/src/main/java/com/penglobe/server/service/DietService.java
@@ -3,7 +3,7 @@ package com.penglobe.server.service;
 import com.penglobe.server.domain.diet.DietRecord;
 import com.penglobe.server.domain.user.User;
 import com.penglobe.server.domain.user.UserCounters;
-import com.penglobe.server.dto.DietDTO;
+import com.penglobe.server.dto.diet.DietDTO;
 import com.penglobe.server.repository.DietRecordRepository;
 import com.penglobe.server.repository.UserCountersRepository;
 import com.penglobe.server.repository.UserRepository;

--- a/src/main/java/com/penglobe/server/service/DietService.java
+++ b/src/main/java/com/penglobe/server/service/DietService.java
@@ -82,7 +82,7 @@ public class DietService {
         // 누적 업데이트 (없으면 생성)
         UserCounters counters = userCountersRepository.findById(userId)
                 .orElse(UserCounters.builder().user(user).userId(userId).build());
-        
+
         BigDecimal current = counters.getTotalDietCo2Kg();
         if (current == null) current = BigDecimal.ZERO;
 

--- a/src/main/java/com/penglobe/server/service/LlmDietService.java
+++ b/src/main/java/com/penglobe/server/service/LlmDietService.java
@@ -1,0 +1,99 @@
+// src/main/java/.../service/LlmCarbonService.java
+package com.penglobe.server.service;
+
+import com.fasterxml.jackson.databind.*;
+import com.penglobe.server.dto.diet.DietResultDTO;
+import com.penglobe.server.dto.diet.DietRequestDTO;
+import com.penglobe.server.llm.GroqClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class LlmDietService {
+
+    private final GroqClient groqClient;
+    private final ObjectMapper om = new ObjectMapper();
+
+    private static BigDecimal roundHalfUp(BigDecimal v, int scale) {
+        return v == null ? null : v.setScale(scale, RoundingMode.HALF_UP);
+    }
+
+    private String buildPrompt(List<DietRequestDTO.FoodItem> items) {
+        try {
+            String itemsJson = om.writerWithDefaultPrettyPrinter().writeValueAsString(items);
+            return """
+      역할: 음식별 탄소배출량 추정기.
+
+      목표:
+      - 아래 '입력 항목'을 보고 각 음식의 kgCO2e를 추정하고, 총합을 계산하라.
+      - 배출계수표는 제공하지 않는다. 너의 일반적인 지식을 사용하되, 확실하지 않으면 추정하지 말고 unknown에 넣어라.
+
+      규칙:
+      - 각 항목의 질량 totalSize(g)를 kg로 환산해 사용한다 (kg = g / 1000).
+      - 가능하면 음식 카테고리를 판단해 전형적인 배출량 범위에 근거해 추정하라.
+      - 불확실하면 보수적(낮은) 추정을 하고, 아주 모호하면 unknown에 넣어라.
+      - 모든 수치는 소수 둘째에서 반올림하여 소수 첫째 자리(HALF_UP)로 반환하라.
+      - 출력은 오직 JSON 한 덩어리만 허용. 여분 텍스트 금지.
+
+      입력 항목(items):
+      %s
+
+      출력 스키마(반드시 엄수):
+      {
+        "totalCo2Kg": number,
+        "items": [ { "name": string, "co2Kg": number } ],
+        "unknown": string[]
+      }
+      """.formatted(itemsJson);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JsonNode parseJsonOnly(String text) {
+        var m = Pattern.compile("\\{[\\s\\S]*\\}").matcher(text);
+        if (!m.find()) throw new IllegalArgumentException("LLM 응답이 JSON이 아님");
+        String json = m.group();
+        try { return om.readTree(json); }
+        catch (Exception e) { throw new IllegalArgumentException("LLM JSON 파싱 실패: " + e.getMessage(), e); }
+    }
+
+    public DietResultDTO calculate(DietRequestDTO req) {
+        String prompt = buildPrompt(req.getItems());
+        String content = groqClient.chat(prompt);
+
+        JsonNode root = parseJsonOnly(content);
+        if (!root.has("totalCo2Kg") || !root.has("items") || !root.has("unknown"))
+            throw new IllegalArgumentException("필수 필드 누락");
+
+        BigDecimal total = roundHalfUp(new BigDecimal(root.get("totalCo2Kg").asText()), 1);
+
+        List<DietResultDTO.ItemResult> items = new ArrayList<>();
+        for (JsonNode n : root.get("items")) {
+            String name = n.get("name").asText();
+            BigDecimal v = roundHalfUp(new BigDecimal(n.get("co2Kg").asText()), 1);
+            items.add(DietResultDTO.ItemResult.builder().name(name).co2Kg(v).build());
+        }
+
+        List<String> unknown = new ArrayList<>();
+        for (JsonNode n : root.get("unknown")) unknown.add(n.asText());
+
+        // 총합 보정 (per-item 합과 0.1 이상 차이나면 교정)
+        BigDecimal sum = items.stream()
+                .map(DietResultDTO.ItemResult::getCo2Kg)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(1, RoundingMode.HALF_UP);
+        if (total == null || total.subtract(sum).abs().compareTo(new BigDecimal("0.1")) > 0) total = sum;
+
+        return DietResultDTO.builder()
+                .totalCo2Kg(total)
+                .items(items)
+                .unknown(unknown)
+                .build();
+    }
+}

--- a/src/main/java/com/penglobe/server/service/MyPageService.java
+++ b/src/main/java/com/penglobe/server/service/MyPageService.java
@@ -73,7 +73,7 @@ public class MyPageService {
 
         BigDecimal dietCo2Kg = dietRecordRepository.findByUserUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay)
                 .stream()
-                .map(record -> BigDecimal.valueOf(Optional.ofNullable(record.getCo2Kg()).orElse(0)))
+                .map(record -> Optional.ofNullable(record.getCo2Kg()).orElse(BigDecimal.ZERO))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         BigDecimal totalCo2Kg = transportCo2Kg.add(dietCo2Kg);


### PR DESCRIPTION
# 📌 PR 제목: llm 연결 추가, llm한테 탄소 배출량 계산 결과 값 받아와서 프론트에게 전달

## ✅ 작업 내용

- diet 관련 기본 server 설정 수정 및 추가
- llm 연결 완료
- 프론트에서 식단 정보 json 으로 받아오기 완료
- 받아 온 정보 llm 에게 전달하여 계산하도록 함
- 계산된 결과 값 반환 완료
- 결과 값 프론트에게 전달 완료
- 총 절약 탄소 배출량 DB 저장 완료

## 🔗 관련 이슈

Closes #115 

## 🧪 테스트

- [ ] 로컬에서 실행 확인
- [ ] DB 연동 확인
- [ ] API 호출 확인

## 📝 기타

- 리뷰어 참고 사항
