### PR TITLE
♻️ refactor: PointsLedger balanceAfter 필드 적용 및 서비스 로직 수정

### DIFF
--- a/src/main/java/com/penglobe/server/domain/ledger/PointsLedger.java
+++ b/src/main/java/com/penglobe/server/domain/ledger/PointsLedger.java
@@ -1,11 +1,10 @@
 package com.penglobe.server.domain.ledger;
+
 import com.penglobe.server.domain.BaseEntity;
 import com.penglobe.server.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
-import java.util.Collection;
 @Entity
 @Table(name = "point_ledger",
         indexes = {
@@ -17,7 +16,8 @@ import java.util.Collection;
 @AllArgsConstructor
 @Builder
 @Setter
-public class PointsLedger extends BaseEntity{
+public class PointsLedger extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "point_id")
@@ -33,4 +33,7 @@ public class PointsLedger extends BaseEntity{
     @Enumerated(EnumType.STRING)
     @Column(name = "reason", nullable = false, length = 30)
     private LedgerReason reason;
+
+    @Column(name = "balance_after", nullable = false)
+    private Integer balanceAfter;  // 변경 후 최종 잔액
 }

--- a/src/main/java/com/penglobe/server/service/AttendanceLogService.java
+++ b/src/main/java/com/penglobe/server/service/AttendanceLogService.java
@@ -117,15 +117,17 @@ public class AttendanceLogService {
 
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new IllegalArgumentException("User Not Fount"));
 
+        int updatedBalance = user.getTotalPoint() + reward;
+        user.setTotalPoint(updatedBalance);
+        userRepository.save(user);
+
         PointsLedger ledger = PointsLedger.builder()
                 .user(userRepository.getReferenceById(userId))
                 .changeAmount(reward)
                 .reason(LedgerReason.ATTENDANCE)
+                .balanceAfter(updatedBalance)
                 .build();
         pointsLedgerRepository.save(ledger);
-
-        user.setTotalPoint(user.getTotalPoint() + reward);
-        userRepository.save(user);
 
         log.setShownAt(today);
         return reward;

--- a/src/main/java/com/penglobe/server/service/DietService.java
+++ b/src/main/java/com/penglobe/server/service/DietService.java
@@ -104,7 +104,9 @@ public class DietService {
         if (ice > 0) {
             Integer current = user.getTotalPoint();
             if (current == null) current = 0;
-            user.setTotalPoint(current + ice);
+
+            int updatedBalance = current + ice;
+            user.setTotalPoint(updatedBalance);
             userRepository.save(user);
 
             // 적립 기록
@@ -112,6 +114,7 @@ public class DietService {
                     .user(user)
                     .changeAmount(ice)
                     .reason(LedgerReason.DIET)
+                    .balanceAfter(updatedBalance)
                     .build();
             pointsLedgerRepository.save(ledger);
         }

--- a/src/main/java/com/penglobe/server/service/MissionService.java
+++ b/src/main/java/com/penglobe/server/service/MissionService.java
@@ -145,13 +145,15 @@ public class MissionService {
 
             int reward = rewardOf(20L);
             User user = userRepo.findById(userId).orElseThrow();
-            user.setTotalPoint(user.getTotalPoint() + reward);
+            int newBalance = user.getTotalPoint() + reward;
+            user.setTotalPoint(newBalance);
 
             pointsLedgerRepo.save(
                     PointsLedger.builder()
                             .user(user)
                             .changeAmount(reward)
                             .reason(LedgerReason.MISSION_REWARD)
+                            .balanceAfter(newBalance)
                             .build()
             );
             return;
@@ -202,6 +204,7 @@ public class MissionService {
                             .user(user)
                             .changeAmount(reward)               // +포인트
                             .reason(LedgerReason.MISSION_REWARD) // 사유(레저 enum)
+                            .balanceAfter(newBalance)
                             .build()
             );
 

--- a/src/main/java/com/penglobe/server/service/OrderService.java
+++ b/src/main/java/com/penglobe/server/service/OrderService.java
@@ -53,6 +53,7 @@ public class OrderService {
                         .user(userRef)
                         .changeAmount(-need)
                         .reason(LedgerReason.SHOP_PURCHASE)
+                        .balanceAfter(userRef.getTotalPoint()) //차감 후 잔액 기록
                         .build()
         );
 

--- a/src/main/java/com/penglobe/server/service/PointLedgerService.java
+++ b/src/main/java/com/penglobe/server/service/PointLedgerService.java
@@ -38,19 +38,17 @@ public class PointLedgerService {
                         l.getCreatedAt(),
                         l.getChangeAmount(),
                         l.getReason(),
-                        l.getUser().getTotalPoint()
+                        l.getBalanceAfter()
                 ))
                 .collect(Collectors.toList());
     }
 
-    // 잔액 조회
+    // 현재 잔액 조회 (Ledger 말고 User 캐시 활용)
     public BalanceDTO getCurrentBalance(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않은 사용자입니다."));
 
-        PointsLedger latest = pointsLedgerRepository.findTopByUserOrderByCreatedAtDesc(user);
-        Integer balance = latest != null ? latest.getUser().getTotalPoint() : 0;
-
-        return new BalanceDTO(balance);
+        return new BalanceDTO(user.getTotalPoint()); // ✅ Ledger 안 거치고 바로 조회
     }
+
 }

--- a/src/main/java/com/penglobe/server/service/QuizQuestionService.java
+++ b/src/main/java/com/penglobe/server/service/QuizQuestionService.java
@@ -54,10 +54,17 @@ public class QuizQuestionService {
 
         // 포인트 지급
         int points = (correctAnswer != null && correctAnswer.equals(userAnswer)) ? 10 : 1;
-        user.setTotalPoint(user.getTotalPoint() + points);
+        int updatedBalance = user.getTotalPoint() + points;
+        user.setTotalPoint(updatedBalance);
 
         // PointsLedger 생성 후 저장
-        PointsLedger ledger = new PointsLedger(null, user, points, LedgerReason.QUIZ);
+        PointsLedger ledger = PointsLedger.builder()
+                .user(user)
+                .changeAmount(points)
+                .reason(LedgerReason.QUIZ)
+                .balanceAfter(updatedBalance)
+                .build();
+
         pointsLedgerRepository.save(ledger);
         userRepository.save(user);
 

--- a/src/main/java/com/penglobe/server/service/TransportActivityService.java
+++ b/src/main/java/com/penglobe/server/service/TransportActivityService.java
@@ -81,13 +81,18 @@ public class TransportActivityService {
 
             if (points > 0) {
                 User user = activity.getUser();
-                user.setTotalPoint(user.getTotalPoint() + points);
+
+                // ✅ 유저 총 포인트 갱신
+                int updatedBalance = user.getTotalPoint() + points;
+                user.setTotalPoint(updatedBalance);
                 userRepository.save(user);
 
+                // ✅ Ledger 생성 시 balanceAfter 반영
                 PointsLedger ledger = PointsLedger.builder()
                         .user(user)
                         .changeAmount(points)
                         .reason(LedgerReason.TRANSPORT_ACTIVITY)
+                        .balanceAfter(updatedBalance)
                         .build();
                 pointsLedgerRepository.save(ledger);
             }


### PR DESCRIPTION
### ✅ 작업 내용

* `User.totalPoint` 갱신 시 `PointsLedger.balanceAfter`를 항상 함께 기록하도록 수정
* `QuizQuestionService`에서 포인트 2번 적립되던 버그 수정
* `DietService`, `TransportActivityService`, `MissionService`, `OrderService`, `AttendanceLogService`에 balanceAfter 반영
* User 캐시 포인트와 Ledger 이력 잔액 정합성 유지

---

### 🔗 관련 이슈

Closes #148 

---

### 🧪 테스트

* [ ] 로컬에서 각 서비스 호출 후 Ledger.balanceAfter 값이 정상 반영되는지 확인
* [ ] User.totalPoint와 Ledger 최신 balanceAfter 값 일치 확인
* [ ] 포인트 적립/차감 중복 발생 여부 확인

